### PR TITLE
Gun throwing breaks gun/destroys NPCS

### DIFF
--- a/Assets/Scenes/sean_pickup.unity
+++ b/Assets/Scenes/sean_pickup.unity
@@ -126,7 +126,7 @@ GameObject:
   - component: {fileID: 77155606}
   m_Layer: 0
   m_Name: Plane
-  m_TagString: Untagged
+  m_TagString: Finish
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -281,7 +281,7 @@ GameObject:
   - component: {fileID: 437843486}
   m_Layer: 10
   m_Name: Cube
-  m_TagString: Untagged
+  m_TagString: npc
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -347,8 +347,8 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 437843480}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.92, y: 0.35, z: 4.33}
-  m_LocalScale: {x: 0.2295386, y: 0.2295386, z: 0.2295386}
+  m_LocalPosition: {x: 0.58, y: 1.31, z: 6.068}
+  m_LocalScale: {x: 1.0667577, y: 2.0362587, z: 0.2295386}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
@@ -366,8 +366,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   destination: {x: 0, y: 0, z: 0}
   player: {fileID: 1757891460}
-  Rb: {fileID: 0}
   cameraScript: {fileID: 534669906}
+  SpawnProjectiles: {fileID: 0}
   pickUpSpeed: 5
   isHolding: 0
 --- !u!54 &437843486
@@ -534,7 +534,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!114 &1326146050
@@ -550,8 +550,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   destination: {x: 0, y: 0, z: 0}
   player: {fileID: 1757891460}
-  Rb: {fileID: 0}
   cameraScript: {fileID: 534669906}
+  SpawnProjectiles: {fileID: 0}
   pickUpSpeed: 5
   isHolding: 0
 --- !u!1001 &1704776373

--- a/Assets/scriptsSean/itemPickUp.cs
+++ b/Assets/scriptsSean/itemPickUp.cs
@@ -80,6 +80,7 @@ public class itemPickUp : MonoBehaviour {
 			transform.rotation = gunPosTrans.rotation;
 			Rb.velocity = Vector3.zero;
 			Rb.angularVelocity = Vector3.zero;
+			Rb.isKinematic = true;
 			SpawnProjectiles.setGunBoolTrue();
 		}
 
@@ -91,6 +92,7 @@ public class itemPickUp : MonoBehaviour {
 		if (itemState == 4)
 		{
 			transform.parent = null;
+			Rb.isKinematic = false;
 			Rb.useGravity = true;
 			Rb.AddForce(Camera.main.transform.forward * throwForce);
 			SpawnProjectiles.setGunBoolFalse();
@@ -106,9 +108,14 @@ public class itemPickUp : MonoBehaviour {
 			itemState = 3;
 		}
 
-		if (itemState == 4 && col.gameObject.tag == "Respawn")
+		if (itemState == 4 && col.gameObject.tag == "Finish")
 		{
-			itemState = 1;
+			Destroy(gameObject);
+		} 
+		else if (itemState == 4 && col.gameObject.tag == "npc")
+		{
+			Destroy(gameObject);
+			Destroy(col.gameObject);
 		}
 	}
 	


### PR DESCRIPTION
Made small changes in itemPickUp script so that the gun deletes itself when it hits the ground or if it hits an npc it deltes both itself and the enemy model.